### PR TITLE
Hidden parking spot number field in the edit view.

### DIFF
--- a/GarageMVC/GarageMVC/Views/Garage/Edit.cshtml
+++ b/GarageMVC/GarageMVC/Views/Garage/Edit.cshtml
@@ -55,6 +55,7 @@
                     <span asp-validation-for="NumberOfWheels" class="text-danger"></span>
                 </div>
                 <br />
+                @Html.HiddenFor(Model => Model.ParkingSpotNumber)
                 <div class="form-group">
                     <input type="submit" value="Save" class="btn btn-primary" />
                 </div>


### PR DESCRIPTION
Allows the parking spot number to be changed by accessing the web interface with things that are not conventional web browesers, which might be a bad idea.